### PR TITLE
Return latest stable of --engine if no package.json specified

### DIFF
--- a/bin/get-version
+++ b/bin/get-version
@@ -4,7 +4,9 @@ var os         = require('os');
 var getVersion = require('../');
 var path       = require('path');
 
-getVersion(argv.engine, path.resolve(process.cwd(), argv._[0]))
+var pkgPath = argv._.length && path.resolve(process.cwd(), argv._[0]);
+
+getVersion(argv.engine, pkgPath)
   .then(function (version) {
     process.stdout.write(version + os.EOL);
     process.exit(0);

--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ var pkg     = require('./lib/package');
 
 module.exports = function (engStr, pkgFile) {
 
-  assert(pkgFile, 'Must specify package file');
-  var pkgData = pkg.read(pkgFile);
+  var pkgData = pkgFile ? pkg.read(pkgFile) : { engines: {} };
 
   assert(pkgData, 'Invalid package file specified');
   assert(engStr, 'Must specify engine');


### PR DESCRIPTION
I have a use-case where I may or may not have a package.json. If I run the tool without supplying a package.json parameter I'd like the most recent stable version of the engine specified:

$ get-version --engine node

> 0.12.2

$ get-version --engine iojs

> 1.6.4
