### PR TITLE
Set `@modulus/standard` version to `0.2.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "winston": "0.9.0"
   },
   "devDependencies": {
-    "@modulus/standard": "*",
+    "@modulus/standard": "0.2.x",
     "code": "1.x.x",
     "lab": "5.x.x",
     "proxyquire": "1.4.0",


### PR DESCRIPTION
- Set `@modulus/standard` version to `0.2.x`

This is just to set a compatible version of standard. There will be a future PR to update standard to the latest. This is not happening now due to the fact that there will be too many code changes to pass the linter.

Closes #7 
