### PR TITLE
Update require-dir dep to enable support for node 8+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2530 @@
+{
+  "name": "get-version",
+  "version": "1.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@modulus/standard": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/@modulus/standard/-/standard-0.2.0.tgz",
+      "integrity": "sha1-IUESWya8t58J8wgsnd9+NSBNM+M=",
+      "dev": true,
+      "requires": {
+        "eslint": "1.10.3",
+        "eslint-config-modulus": "0.2.0",
+        "eslint-plugin-hapi": "4.0.0",
+        "eslint-plugin-promiseparams": "1.0.7",
+        "standard-engine": "2.2.5"
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "dev": true,
+      "optional": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.1.11",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/asn1/-/asn1-0.1.11.tgz",
+      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+    },
+    "assert-plus": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/assert-plus/-/assert-plus-0.1.5.tgz",
+      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "aws-sign2": {
+      "version": "0.5.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/aws-sign2/-/aws-sign2-0.5.0.tgz",
+      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bl": {
+      "version": "0.9.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "requires": {
+        "readable-stream": "1.0.34"
+      }
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "bossy": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/bossy/-/bossy-1.0.3.tgz",
+      "integrity": "sha1-p9JHiuDC33X0cJi5ute9ZB7tX68=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "caseless": {
+      "version": "0.9.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/caseless/-/caseless-0.9.0.tgz",
+      "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/cli-width/-/cli-width-1.1.1.tgz",
+      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "clone": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "dev": true
+    },
+    "code": {
+      "version": "1.5.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/code/-/code-1.5.0.tgz",
+      "integrity": "sha1-1hWfvQ7p+ERRZ4CdQ7XNm8QFEDo=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "combined-stream": {
+      "version": "0.0.7",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/combined-stream/-/combined-stream-0.0.7.tgz",
+      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "requires": {
+        "delayed-stream": "0.0.5"
+      }
+    },
+    "commander": {
+      "version": "2.13.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.38"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.3"
+      }
+    },
+    "deglob": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/deglob/-/deglob-1.1.2.tgz",
+      "integrity": "sha1-dtV3wl/j9zKUEqK1nq3qV6xQDj8=",
+      "dev": true,
+      "requires": {
+        "find-root": "1.1.0",
+        "glob": "7.1.2",
+        "ignore": "3.3.7",
+        "pkg-config": "1.1.1",
+        "run-parallel": "1.1.6",
+        "uniq": "1.0.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "find-root": {
+          "version": "1.1.0",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/find-root/-/find-root-1.1.0.tgz",
+          "integrity": "sha1-q8/Iunb3CMQql7PWhbfpRQv7nOQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "delayed-stream": {
+      "version": "0.0.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6",
+        "wrappy": "1.0.2"
+      }
+    },
+    "diff": {
+      "version": "2.2.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/diff/-/diff-2.2.3.tgz",
+      "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "0.7.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/doctrine/-/doctrine-0.7.2.tgz",
+      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+      "dev": true,
+      "requires": {
+        "esutils": "1.1.6",
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.38",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha1-+n1A1lu8m7imfh0/nMZWoAUw7tM=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint/-/eslint-1.10.3.tgz",
+      "integrity": "sha1-+xmpGxPBWAgrvKKUsX2Xm8g1Ogo=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "0.7.2",
+        "escape-string-regexp": "1.0.5",
+        "escope": "3.6.0",
+        "espree": "2.2.5",
+        "estraverse": "4.2.0",
+        "estraverse-fb": "1.3.2",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "5.0.15",
+        "globals": "8.18.0",
+        "handlebars": "4.0.11",
+        "inquirer": "0.11.4",
+        "is-my-json-valid": "2.17.1",
+        "is-resolvable": "1.0.1",
+        "js-yaml": "3.4.5",
+        "json-stable-stringify": "1.0.1",
+        "lodash.clonedeep": "3.0.2",
+        "lodash.merge": "3.3.2",
+        "lodash.omit": "3.1.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "optionator": "0.6.0",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "shelljs": "0.5.3",
+        "strip-json-comments": "1.0.4",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0",
+        "xml-escape": "1.0.0"
+      }
+    },
+    "eslint-config-hapi": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint-config-hapi/-/eslint-config-hapi-2.0.1.tgz",
+      "integrity": "sha1-OR7kokI6icim5QduQ04W+IkaqXI=",
+      "dev": true
+    },
+    "eslint-config-modulus": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint-config-modulus/-/eslint-config-modulus-0.2.0.tgz",
+      "integrity": "sha1-T65JRpO+tGtXWIvdlMht9O/CkQQ=",
+      "dev": true
+    },
+    "eslint-plugin-hapi": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint-plugin-hapi/-/eslint-plugin-hapi-4.0.0.tgz",
+      "integrity": "sha1-RKouRfeTmlI5Kc2DK7mqEpqV6CM=",
+      "dev": true,
+      "requires": {
+        "hapi-capitalize-modules": "1.1.6",
+        "hapi-for-you": "1.0.0",
+        "hapi-scope-start": "2.1.1",
+        "no-arrowception": "1.0.0"
+      }
+    },
+    "eslint-plugin-promiseparams": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint-plugin-promiseparams/-/eslint-plugin-promiseparams-1.0.7.tgz",
+      "integrity": "sha1-6Ubr6KlpwJE1E/bJ9PnKB7Aer88=",
+      "dev": true
+    },
+    "espree": {
+      "version": "2.2.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz",
+      "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "estraverse-fb": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+      "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true,
+      "optional": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "fast-levenshtein": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "find-root": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/find-root/-/find-root-0.1.2.tgz",
+      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE=",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/form-data/-/form-data-0.2.0.tgz",
+      "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+      "requires": {
+        "async": "0.9.2",
+        "combined-stream": "0.0.7",
+        "mime-types": "2.0.14"
+      }
+    },
+    "formatio": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.3"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "8.18.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz",
+      "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "hapi-capitalize-modules": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
+      "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
+      "dev": true
+    },
+    "hapi-for-you": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
+      "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
+      "dev": true
+    },
+    "hapi-scope-start": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
+      "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/har-validator/-/har-validator-1.8.0.tgz",
+      "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
+      "requires": {
+        "bluebird": "2.11.0",
+        "chalk": "1.1.3",
+        "commander": "2.13.0",
+        "is-my-json-valid": "2.17.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "hawk": {
+      "version": "2.3.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/hawk/-/hawk-2.3.1.tgz",
+      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "http-signature": {
+      "version": "0.10.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/http-signature/-/http-signature-0.10.1.tgz",
+      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+      "requires": {
+        "asn1": "0.1.11",
+        "assert-plus": "0.1.5",
+        "ctype": "0.5.3"
+      }
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "0.11.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/inquirer/-/inquirer-0.11.4.tgz",
+      "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "1.1.1",
+        "figures": "1.7.0",
+        "lodash": "3.6.0",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-my-json-valid": {
+      "version": "2.17.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha1-PamJFKcKIvCoVj7xURokbG/FVHE=",
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+    },
+    "is-resolvable": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.0.1.tgz",
+      "integrity": "sha1-rMoc022+RLl0uSQyFVWnC6A7HPQ=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "items": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/items/-/items-1.1.1.tgz",
+      "integrity": "sha1-Q1td0hvKKLPP0lu1xrJ4txUBD9k=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.4.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-3.4.5.tgz",
+      "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        }
+      }
+    },
+    "jslint": {
+      "version": "0.9.8",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/jslint/-/jslint-0.9.8.tgz",
+      "integrity": "sha1-uSyoXKhtaoKXchCO6RnshJ3EsSk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "4.5.3",
+        "nopt": "3.0.6",
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "lab": {
+      "version": "5.18.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lab/-/lab-5.18.1.tgz",
+      "integrity": "sha1-Sr87Q/up/YnlFaIzCL5RzWdnyGU=",
+      "dev": true,
+      "requires": {
+        "bossy": "1.0.3",
+        "diff": "2.2.3",
+        "eslint": "1.5.1",
+        "eslint-config-hapi": "2.0.1",
+        "eslint-plugin-hapi": "1.2.2",
+        "espree": "2.2.5",
+        "handlebars": "4.0.11",
+        "hoek": "2.16.3",
+        "items": "1.1.1",
+        "jslint": "0.9.8",
+        "json-stringify-safe": "5.0.1",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.3.3"
+      },
+      "dependencies": {
+        "eslint": {
+          "version": "1.5.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint/-/eslint-1.5.1.tgz",
+          "integrity": "sha1-u54WHwFh1xuF3EgWO/FKhvICVis=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.9",
+            "doctrine": "0.7.2",
+            "escape-string-regexp": "1.0.5",
+            "escope": "3.6.0",
+            "espree": "2.2.5",
+            "estraverse": "4.2.0",
+            "estraverse-fb": "1.3.2",
+            "file-entry-cache": "1.3.1",
+            "glob": "5.0.15",
+            "globals": "8.18.0",
+            "handlebars": "4.0.11",
+            "inquirer": "0.9.0",
+            "is-my-json-valid": "2.17.1",
+            "is-resolvable": "1.0.1",
+            "js-yaml": "3.4.5",
+            "lodash.clonedeep": "3.0.2",
+            "lodash.merge": "3.3.2",
+            "lodash.omit": "3.1.0",
+            "minimatch": "2.0.10",
+            "mkdirp": "0.5.1",
+            "object-assign": "2.1.1",
+            "optionator": "0.5.0",
+            "path-is-absolute": "1.0.1",
+            "path-is-inside": "1.0.2",
+            "shelljs": "0.3.0",
+            "strip-json-comments": "1.0.4",
+            "text-table": "0.2.0",
+            "to-double-quotes": "1.0.2",
+            "to-single-quotes": "1.0.4",
+            "user-home": "1.1.1",
+            "xml-escape": "1.0.0"
+          }
+        },
+        "eslint-plugin-hapi": {
+          "version": "1.2.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint-plugin-hapi/-/eslint-plugin-hapi-1.2.2.tgz",
+          "integrity": "sha1-QcwGNDhxibEcAGdWM6cVZGq4lJA=",
+          "dev": true,
+          "requires": {
+            "hapi-capitalize-modules": "1.1.6",
+            "hapi-scope-start": "1.1.4",
+            "no-shadow-relaxed": "1.0.1"
+          }
+        },
+        "get-stdin": {
+          "version": "3.0.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/get-stdin/-/get-stdin-3.0.2.tgz",
+          "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4=",
+          "dev": true
+        },
+        "hapi-scope-start": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/hapi-scope-start/-/hapi-scope-start-1.1.4.tgz",
+          "integrity": "sha1-VxC1r7dOdJYdrn6wmdjYvkp1sA4=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.9.0",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/inquirer/-/inquirer-0.9.0.tgz",
+          "integrity": "sha1-c2bjijMeYZBJWKzlstpKml9jZ5g=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.6.0",
+            "readline2": "0.1.1",
+            "run-async": "0.1.0",
+            "rx-lite": "2.5.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.4",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/mute-stream/-/mute-stream-0.0.4.tgz",
+          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.5.0",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/optionator/-/optionator-0.5.0.tgz",
+          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/readline2/-/readline2-0.1.1.tgz",
+          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+          "dev": true,
+          "requires": {
+            "mute-stream": "0.0.4",
+            "strip-ansi": "2.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "1.1.1"
+              }
+            }
+          }
+        },
+        "rx-lite": {
+          "version": "2.5.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/rx-lite/-/rx-lite-2.5.2.tgz",
+          "integrity": "sha1-X+9C1Nbna6tRmdIXEyfbcJ5Y5jQ=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/shelljs/-/shelljs-0.3.0.tgz",
+          "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+          "dev": true
+        },
+        "to-double-quotes": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
+          "integrity": "sha1-u27TbHhjTD1k/YelGtWGDcWU7f0=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "3.0.2"
+          }
+        },
+        "to-single-quotes": {
+          "version": "1.0.4",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
+          "integrity": "sha1-LuqBma8myhFx9TV8WeGS1WXuUxM=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "3.0.2"
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+          "dev": true
+        }
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "levn": {
+      "version": "0.2.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/levn/-/levn-0.2.5.tgz",
+      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "3.6.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash/-/lodash-3.6.0.tgz",
+      "integrity": "sha1-Umao9J3Zib5Pn2gbbyoMVShdDZo="
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "dev": true
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "dev": true
+    },
+    "lodash._arraymap": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._baseassign": "3.2.0",
+        "lodash._basefor": "3.0.3",
+        "lodash.isarray": "3.0.4",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basedifference": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+      "dev": true,
+      "requires": {
+        "lodash._baseindexof": "3.1.0",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2"
+      }
+    },
+    "lodash._baseflatten": {
+      "version": "3.1.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "dev": true
+    },
+    "lodash._baseindexof": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._cacheindexof": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+      "dev": true
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash._createcache": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1"
+      }
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._pickbyarray": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
+      "dev": true
+    },
+    "lodash._pickbycallback": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "dev": true,
+      "requires": {
+        "lodash._baseclone": "3.3.0",
+        "lodash._bindcallback": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.isarguments": "3.1.0",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.merge": {
+      "version": "3.3.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4",
+        "lodash.isplainobject": "3.2.0",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2",
+        "lodash.keysin": "3.0.8",
+        "lodash.toplainobject": "3.0.0"
+      }
+    },
+    "lodash.omit": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+      "dev": true,
+      "requires": {
+        "lodash._arraymap": "3.0.0",
+        "lodash._basedifference": "3.0.3",
+        "lodash._baseflatten": "3.1.4",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._pickbyarray": "3.0.2",
+        "lodash._pickbycallback": "3.0.0",
+        "lodash.keysin": "3.0.8",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.toplainobject": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lolex": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/lolex/-/lolex-1.1.0.tgz",
+      "integrity": "sha1-Xbu8hQOV51I8dLNYb3+9JibSWxs=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.12.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/mime-db/-/mime-db-1.12.0.tgz",
+      "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+    },
+    "mime-types": {
+      "version": "2.0.14",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/mime-types/-/mime-types-2.0.14.tgz",
+      "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+      "requires": {
+        "mime-db": "1.12.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/minimist/-/minimist-1.1.1.tgz",
+      "integrity": "sha1-G8K8cWWM3KVxJHVoQ2NhWwtPaVs="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "multiline": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/multiline/-/multiline-1.0.2.tgz",
+      "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
+      "dev": true,
+      "requires": {
+        "strip-indent": "1.0.1"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "no-arrowception": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/no-arrowception/-/no-arrowception-1.0.0.tgz",
+      "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
+      "dev": true
+    },
+    "no-shadow-relaxed": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/no-shadow-relaxed/-/no-shadow-relaxed-1.0.1.tgz",
+      "integrity": "sha1-z2zAFAL0IwuE/TvYoVZG3d8i7fI=",
+      "dev": true,
+      "requires": {
+        "eslint": "0.24.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
+          "dev": true
+        },
+        "doctrine": {
+          "version": "0.6.4",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/doctrine/-/doctrine-0.6.4.tgz",
+          "integrity": "sha1-gUKEkalC7xiwSSBW7aOADu5X1h0=",
+          "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "0.0.1"
+          }
+        },
+        "eslint": {
+          "version": "0.24.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint/-/eslint-0.24.1.tgz",
+          "integrity": "sha1-VKUICYVbllVyHG8u5Xs1HtzigQE=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.9",
+            "doctrine": "0.6.4",
+            "escape-string-regexp": "1.0.5",
+            "escope": "3.6.0",
+            "espree": "2.2.5",
+            "estraverse": "4.2.0",
+            "estraverse-fb": "1.3.2",
+            "globals": "8.18.0",
+            "inquirer": "0.8.5",
+            "is-my-json-valid": "2.17.1",
+            "js-yaml": "3.4.5",
+            "minimatch": "2.0.10",
+            "mkdirp": "0.5.1",
+            "object-assign": "2.1.1",
+            "optionator": "0.5.0",
+            "path-is-absolute": "1.0.1",
+            "strip-json-comments": "1.0.4",
+            "text-table": "0.2.0",
+            "user-home": "1.1.1",
+            "xml-escape": "1.0.0"
+          }
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.8.5",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/inquirer/-/inquirer-0.8.5.tgz",
+          "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "1.1.1",
+            "chalk": "1.1.3",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.6.0",
+            "readline2": "0.1.1",
+            "rx": "2.5.3",
+            "through": "2.3.8"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.4",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/mute-stream/-/mute-stream-0.0.4.tgz",
+          "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.5.0",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/optionator/-/optionator-0.5.0.tgz",
+          "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/readline2/-/readline2-0.1.1.tgz",
+          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+          "dev": true,
+          "requires": {
+            "mute-stream": "0.0.4",
+            "strip-ansi": "2.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "1.1.1"
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+          "dev": true
+        }
+      }
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.6.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/oauth-sign/-/oauth-sign-0.6.0.tgz",
+      "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.6.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/optionator/-/optionator-0.6.0.tgz",
+      "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "1.0.7",
+        "levn": "0.2.5",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "0.0.3"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "1.0.1",
+        "find-root": "1.1.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "find-root": {
+          "version": "1.1.0",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/find-root/-/find-root-1.1.0.tgz",
+          "integrity": "sha1-q8/Iunb3CMQql7PWhbfpRQv7nOQ=",
+          "dev": true
+        }
+      }
+    },
+    "pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "proxyquire": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/proxyquire/-/proxyquire-1.4.0.tgz",
+      "integrity": "sha1-vR9kGuHvOl/Sqfr/un3EEO69qSw=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/q/-/q-1.2.0.tgz",
+      "integrity": "sha1-gRcFzkqYAq3/gRqw/NvQGUbh/iI="
+    },
+    "qs": {
+      "version": "2.4.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/qs/-/qs-2.4.2.tgz",
+      "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o="
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.54.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/request/-/request-2.54.0.tgz",
+      "integrity": "sha1-oTkXzY6PpzMy2gvy+EowGB3vGVM=",
+      "requires": {
+        "aws-sign2": "0.5.0",
+        "bl": "0.9.5",
+        "caseless": "0.9.0",
+        "combined-stream": "0.0.7",
+        "forever-agent": "0.6.1",
+        "form-data": "0.2.0",
+        "har-validator": "1.8.0",
+        "hawk": "2.3.1",
+        "http-signature": "0.10.1",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.0.14",
+        "node-uuid": "1.4.8",
+        "oauth-sign": "0.6.0",
+        "qs": "2.4.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.4.3"
+      }
+    },
+    "require-dir": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/require-dir/-/require-dir-0.3.2.tgz",
+      "integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/run-parallel/-/run-parallel-1.1.6.tgz",
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+      "dev": true
+    },
+    "rx": {
+      "version": "2.5.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/rx/-/rx-2.5.3.tgz",
+      "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/samsam/-/samsam-1.1.3.tgz",
+      "integrity": "sha1-n1CHQZtNCR8jJXHn+lLpCw9VJiE=",
+      "dev": true
+    },
+    "semver": {
+      "version": "4.3.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/semver/-/semver-4.3.1.tgz",
+      "integrity": "sha1-vrASlXW5X3YRCymvCNNw/Z7rNL8="
+    },
+    "shelljs": {
+      "version": "0.5.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/shelljs/-/shelljs-0.5.3.tgz",
+      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "1.14.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/sinon/-/sinon-1.14.1.tgz",
+      "integrity": "sha1-2CeXhBkYc0UHyUt6c+P1YJBFeK0=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.1.0",
+        "util": "0.10.3"
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "source-map-support": {
+      "version": "0.3.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/source-map-support/-/source-map-support-0.3.3.tgz",
+      "integrity": "sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.1.32"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.1.32.tgz",
+          "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "standard-engine": {
+      "version": "2.2.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/standard-engine/-/standard-engine-2.2.5.tgz",
+      "integrity": "sha1-ornUQZ9kiiIbjReCP7dFQG83w04=",
+      "dev": true,
+      "requires": {
+        "defaults": "1.0.3",
+        "deglob": "1.1.2",
+        "dezalgo": "1.0.3",
+        "eslint": "1.9.0",
+        "find-root": "0.1.2",
+        "get-stdin": "4.0.1",
+        "minimist": "1.1.1",
+        "multiline": "1.0.2",
+        "pkg-config": "1.1.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "eslint": {
+          "version": "1.9.0",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/eslint/-/eslint-1.9.0.tgz",
+          "integrity": "sha1-p1qvB+KGUHcu0OcNqizggwebZRQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "debug": "2.6.9",
+            "doctrine": "0.7.2",
+            "escape-string-regexp": "1.0.5",
+            "escope": "3.6.0",
+            "espree": "2.2.5",
+            "estraverse": "4.2.0",
+            "estraverse-fb": "1.3.2",
+            "esutils": "2.0.2",
+            "file-entry-cache": "1.3.1",
+            "glob": "5.0.15",
+            "globals": "8.18.0",
+            "handlebars": "4.0.11",
+            "inquirer": "0.11.4",
+            "is-my-json-valid": "2.17.1",
+            "is-resolvable": "1.0.1",
+            "js-yaml": "3.4.5",
+            "json-stable-stringify": "1.0.1",
+            "lodash.clonedeep": "3.0.2",
+            "lodash.merge": "3.3.2",
+            "lodash.omit": "3.1.0",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "optionator": "0.6.0",
+            "path-is-absolute": "1.0.1",
+            "path-is-inside": "1.0.2",
+            "shelljs": "0.5.3",
+            "strip-json-comments": "1.0.4",
+            "text-table": "0.2.0",
+            "to-double-quotes": "2.0.0",
+            "to-single-quotes": "2.0.1",
+            "user-home": "2.0.0",
+            "xml-escape": "1.0.0"
+          }
+        }
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "to-double-quotes": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
+      "integrity": "sha1-qvIx1vqUiUn4GTAburRITYWI5Kc=",
+      "dev": true
+    },
+    "to-single-quotes": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
+      "integrity": "sha1-fMKRUfD18sQZRvEZ9ZMv5VQXASU=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "winston": {
+      "version": "0.9.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/winston/-/winston-0.9.0.tgz",
+      "integrity": "sha1-tXJubEIpHjBeNihs566fO3SlJ6g=",
+      "requires": {
+        "async": "0.9.2",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.10"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "xml-escape": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/xml-escape/-/xml-escape-1.0.0.tgz",
+      "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://artifactory.impinj.com:443/artifactory/api/npm/npm-virtual/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-version",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Get versions list for npm, node and iojs",
   "main": "index.js",
   "bin": {
@@ -34,7 +34,7 @@
     "minimist": "1.1.1",
     "q": "1.2.0",
     "request": "2.54.0",
-    "require-dir": "0.3.0",
+    "require-dir": "^0.3.0",
     "semver": "4.3.1",
     "winston": "0.9.0"
   },


### PR DESCRIPTION
get-version was failing when used with node 8+. I traced this to a problem in the require-dir 0.3.0 dependency. However, I saw that the problem was fixed in 0.3.2. Could you merge this change and push the package to npm? 

Many thanks. 